### PR TITLE
Fixing issue with storage copy compression losing the target name

### DIFF
--- a/system/storage/service.go
+++ b/system/storage/service.go
@@ -85,7 +85,12 @@ func (s *service) compressSource(context *endly.Context, source, target *url.Res
 
 	if err = source.Rename(archiveName); err == nil {
 		if path.Ext(target.ParsedURL.Path) != "" {
-			err = target.Rename(archiveName)
+			_, targetName := path.Split(target.ParsedURL.Path)
+			if name != targetName {
+				err = target.Rename(fmt.Sprintf("%v.tar.gz", targetName))
+			} else {
+				err = target.Rename(archiveName)
+			}
 		} else {
 			target.URL = toolbox.URLPathJoin(target.URL, archiveName)
 			target.ParsedURL, _ = url2.Parse(target.URL)

--- a/system/storage/service_test.go
+++ b/system/storage/service_test.go
@@ -98,13 +98,13 @@ func TestTransferService_Copy(t *testing.T) {
 				Transfers: []*storage.Transfer{
 					{
 						Source:   url.NewResource("scp://127.0.0.1:22/tmp/copy2_source/config2.json"),
-						Dest:     url.NewResource("/tmp/copy4_target/config2.json"),
+						Dest:     url.NewResource("/tmp/copy4_target/config4.json"),
 						Compress: true,
 					},
 				},
 			},
 			map[string]string{
-				"mem:///tmp/copy4_target/config2.json.tar.gz": "xyz",
+				"mem:///tmp/copy4_target/config4.json.tar.gz": "xyz",
 			},
 			"",
 		},


### PR DESCRIPTION
Minor fix to patch target name when copying with compression.