### PR TITLE
Allow extract regexps to be required

### DIFF
--- a/deployment/sdk/go.go
+++ b/deployment/sdk/go.go
@@ -23,7 +23,7 @@ func (s *goService) setSdk(context *endly.Context, request *SetRequest) (*Info, 
 
 	var extractRequest = exec.NewExtractRequest(request.Target, exec.DefaultOptions(),
 		exec.NewExtractCommand("go version", "", nil, nil,
-			model.NewExtract("version", "go version go([^\\s]+)", false)),
+			model.NewExtract("version", "go version go([^\\s]+)", false, false)),
 	)
 
 	extractRequest.SystemPaths = append(extractRequest.SystemPaths, fmt.Sprintf("%v/bin", sdkHome))

--- a/deployment/sdk/jdk.go
+++ b/deployment/sdk/jdk.go
@@ -19,10 +19,10 @@ func (s *jdkService) checkJavaVersion(context *endly.Context, jdkCandidate strin
 	extractRequest := exec.NewExtractRequest(request.Target, exec.DefaultOptions(),
 		exec.NewExtractCommand(jdkCandidate+"java -version", "", nil,
 			util.StdErrors,
-			model.NewExtract("build", "build (\\d\\.\\d).+", false)),
+			model.NewExtract("build", "build (\\d\\.\\d).+", false, false)),
 		exec.NewExtractCommand(fmt.Sprintf(jdkCandidate+"jrunscript -e 'java.lang.System.out.println(java.lang.System.getProperty(\"java.home\"));'"), "", nil,
 			util.StdErrors,
-			model.NewExtract("JAVA_HOME", "(.+)", false)))
+			model.NewExtract("JAVA_HOME", "(.+)", false, false)))
 
 	commandResponse := &exec.RunResponse{}
 	if err := endly.Run(context, extractRequest, commandResponse); err != nil {
@@ -66,8 +66,8 @@ func (s *jdkService) setSdk(context *endly.Context, request *SetRequest) (*Info,
 	jdkHomeCheckCommand := s.getJavaHomeCheckCommand(context, request)
 	extractRequest := exec.NewExtractRequest(request.Target, exec.DefaultOptions(),
 		exec.NewExtractCommand(jdkHomeCheckCommand, "", nil, util.StdErrors,
-			model.NewExtract("JAVA_HOME", "(.+jdk.+)", false),
-			model.NewExtract("JAVA_HOME", "(.+jvm.+)", false)))
+			model.NewExtract("JAVA_HOME", "(.+jdk.+)", false, false),
+			model.NewExtract("JAVA_HOME", "(.+jvm.+)", false, false)))
 
 	commandResponse := &exec.RunResponse{}
 	if err := endly.Run(context, extractRequest, commandResponse); err != nil {

--- a/deployment/sdk/node.go
+++ b/deployment/sdk/node.go
@@ -18,7 +18,7 @@ func (s *nodeService) setSdk(context *endly.Context, request *SetRequest) (*Info
 	var runResponse = &exec.RunResponse{}
 	var extractRequest = exec.NewExtractRequest(request.Target, exec.DefaultOptions(),
 		exec.NewExtractCommand("node -v", "", nil, nil,
-			model.NewExtract("version", "v([^\\s]+)", false)),
+			model.NewExtract("version", "v([^\\s]+)", false, false)),
 	)
 	extractRequest.SystemPaths = append(extractRequest.SystemPaths, fmt.Sprintf("%v/bin", sdkHome))
 	if err := endly.Run(context, extractRequest, runResponse); err != nil {

--- a/deployment/vc/git.go
+++ b/deployment/vc/git.go
@@ -89,10 +89,10 @@ func (s *git) checkInfo(context *endly.Context, request *StatusRequest) (*Status
 
 	runRequest := exec.NewExtractRequest(request.Source, exec.DefaultOptions(),
 		exec.NewExtractCommand(fmt.Sprintf("git status"), "", nil, nil,
-			model.NewExtract("branch", "On branch[\\s\\t]+([^\\s]+)", true)),
+			model.NewExtract("branch", "On branch[\\s\\t]+([^\\s]+)", true, false)),
 
 		exec.NewExtractCommand(fmt.Sprintf("git remote -v"), "", nil, nil,
-			model.NewExtract("origin", "origin[\\s\\t]+([^\\s]+)\\s+\\(fetch\\)", true)),
+			model.NewExtract("origin", "origin[\\s\\t]+([^\\s]+)\\s+\\(fetch\\)", true, false)),
 		exec.NewExtractCommand(fmt.Sprintf("git rev-parse HEAD"), "", nil, nil))
 
 	if err = endly.Run(context, runRequest, runResponse); err != nil {

--- a/deployment/vc/svn.go
+++ b/deployment/vc/svn.go
@@ -29,8 +29,8 @@ func (s *svnService) checkInfo(context *endly.Context, request *StatusRequest) (
 	extractRequest := exec.NewExtractRequest(target,
 		exec.DefaultOptions(),
 		exec.NewExtractCommand(fmt.Sprintf("svn info"), "", nil, nil,
-			model.NewExtract("origin", "^URL:[\\t\\s]+([^\\s]+)", false),
-			model.NewExtract("revision", "Revision:\\s+([^\\s]+)", false)),
+			model.NewExtract("origin", "^URL:[\\t\\s]+([^\\s]+)", false, false),
+			model.NewExtract("revision", "Revision:\\s+([^\\s]+)", false, false)),
 		exec.NewExtractCommand(fmt.Sprintf("svn stat"), "", nil, nil))
 
 	if err = endly.Run(context, extractRequest, runResponse); err != nil {

--- a/model/extracts.go
+++ b/model/extracts.go
@@ -90,7 +90,7 @@ func NewExtract(key, regExpr string, reset bool, required bool) *Extract {
 		RegExpr: regExpr,
 		Key:     key,
 		Reset:   reset,
-    Required: required,
+		Required: required,
 	}
 }
 

--- a/model/extracts.go
+++ b/model/extracts.go
@@ -41,14 +41,22 @@ func (d *Extracts) Extract(context *endly.Context, extracted map[string]interfac
 				continue
 			}
 		}
+    matched := false
 		for _, line := range inputs {
 			if len(line) == 0 {
 				continue
 			}
-			if !matchExpression(compiledExpression, line, extract, context, extracted) {
-				cleanedLine := vtclean.Clean(line, false)
-				matchExpression(compiledExpression, cleanedLine, extract, context, extracted)
+			if matchExpression(compiledExpression, line, extract, context, extracted) {
+				matched = true
+				continue
 			}
+			cleanedLine := vtclean.Clean(line, false)
+			if(matchExpression(compiledExpression, cleanedLine, extract, context, extracted)) {
+				matched = true
+			}
+		}
+		if extract.Required && !matched {
+			return fmt.Errorf("failed to extract required data - no match found for regexpr: %v,  %v", extract.RegExpr, multiLines)
 		}
 	}
 	return nil
@@ -70,17 +78,19 @@ func NewExtracts() Extracts {
 
 //Extract represents a data extraction
 type Extract struct {
-	RegExpr string `description:"regular expression with oval bracket to extract match pattern"`            //regular expression
-	Key     string `description:"state key to store a match"`                                               //state key to store a match
-	Reset   bool   `description:"reset the key in the context before evaluating this data extraction rule"` //reset the key in the context before evaluating this data extraction rule
+	RegExpr  string `description:"regular expression with oval bracket to extract match pattern"`            //regular expression
+	Key      string `description:"state key to store a match"`                                               //state key to store a match
+	Reset    bool   `description:"reset the key in the context before evaluating this data extraction rule"` //reset the key in the context before evaluating this data extraction rule
+  Required bool   `description:"require that at least one pattern match is returned"`                      //require that at least one pattern match is returned
 }
 
 //NewExtract creates a new data extraction
-func NewExtract(key, regExpr string, reset bool) *Extract {
+func NewExtract(key, regExpr string, reset bool, required bool) *Extract {
 	return &Extract{
 		RegExpr: regExpr,
 		Key:     key,
 		Reset:   reset,
+    Required: required,
 	}
 }
 

--- a/model/extracts.go
+++ b/model/extracts.go
@@ -81,7 +81,7 @@ type Extract struct {
 	RegExpr  string `description:"regular expression with oval bracket to extract match pattern"`            //regular expression
 	Key      string `description:"state key to store a match"`                                               //state key to store a match
 	Reset    bool   `description:"reset the key in the context before evaluating this data extraction rule"` //reset the key in the context before evaluating this data extraction rule
-  Required bool   `description:"require that at least one pattern match is returned"`                      //require that at least one pattern match is returned
+	Required bool   `description:"require that at least one pattern match is returned"`                      //require that at least one pattern match is returned
 }
 
 //NewExtract creates a new data extraction

--- a/system/daemon/service.go
+++ b/system/daemon/service.go
@@ -156,8 +156,8 @@ func (s *service) determineCheckCommand(context *endly.Context, target *url.Reso
 		if info.Pid > 0 {
 			var runResponse = &exec.RunResponse{}
 			var extractRequest = exec.NewExtractRequest(target, exec.DefaultOptions(), exec.NewExtractCommand(fmt.Sprintf("launchctl procinfo %v", info.Pid), "", nil, []string{"Unrecognized"},
-				model.NewExtract("path", "program path[\\s|\\t]+=[\\s|\\t]+([^\\s]+)", false),
-				model.NewExtract("state", "state = (running)", false)))
+				model.NewExtract("path", "program path[\\s|\\t]+=[\\s|\\t]+([^\\s]+)", false, false),
+				model.NewExtract("state", "state = (running)", false, false)))
 			extractRequest.SuperUser = true
 
 			err = endly.Run(context, extractRequest, runResponse)
@@ -220,10 +220,10 @@ func (s *service) checkService(context *endly.Context, request *StatusRequest) (
 
 	commandResult, err := s.executeCommand(context, serviceType, target, exec.NewExtractRequest(
 		target, options, exec.NewExtractCommand(command, "", nil, nil,
-			model.NewExtract("pid", "[^└]+└─(\\d+).+", true),
-			model.NewExtract("pid", "Main PID: (\\d+).+", false),
-			model.NewExtract("state", "[\\s|\\t]+Active:\\s+(\\S+)", false),
-			model.NewExtract("path", "[^└]+└─\\d+[\\s\\t].(.+)", false)),
+			model.NewExtract("pid", "[^└]+└─(\\d+).+", true, false),
+			model.NewExtract("pid", "Main PID: (\\d+).+", false, false),
+			model.NewExtract("state", "[\\s|\\t]+Active:\\s+(\\S+)", false, false),
+			model.NewExtract("path", "[^└]+└─\\d+[\\s\\t].(.+)", false, false)),
 		exec.NewExtractCommand("Q", "(END)", nil, nil)))
 
 	if err != nil {


### PR DESCRIPTION
We've found a lot of our errors are caused by commands not returning the expected output. Later commands that depend on variables initialized from the first command fail because the variables are not set to their expected values. We've been handling this with asserts, but it adds a lot of redundant code.

This allows us to specify that we expect at least once match for an expect and to fail if it doesn't match. 