### PR TITLE
Allowed a required regexp to only have to match once

### DIFF
--- a/model/extracts.go
+++ b/model/extracts.go
@@ -17,6 +17,7 @@ func (d *Extracts) Extract(context *endly.Context, extracted map[string]interfac
 	if len(*d) == 0 || len(inputs) == 0 {
 		return nil
 	}
+
 	for _, extract := range *d {
 		if extract.Reset {
 			delete(extracted, extract.Key)
@@ -41,7 +42,7 @@ func (d *Extracts) Extract(context *endly.Context, extracted map[string]interfac
 				continue
 			}
 		}
-    matched := false
+		matched := false
 		for _, line := range inputs {
 			if len(line) == 0 {
 				continue
@@ -51,11 +52,16 @@ func (d *Extracts) Extract(context *endly.Context, extracted map[string]interfac
 				continue
 			}
 			cleanedLine := vtclean.Clean(line, false)
-			if(matchExpression(compiledExpression, cleanedLine, extract, context, extracted)) {
+			if matchExpression(compiledExpression, cleanedLine, extract, context, extracted) {
 				matched = true
+				continue
 			}
 		}
 		if extract.Required && !matched {
+			if _, ok := extracted[extract.Key]; ok {
+				// we found a value at some point, continue
+				continue
+			}
 			return fmt.Errorf("failed to extract required data - no match found for regexpr: %v,  %v", extract.RegExpr, multiLines)
 		}
 	}
@@ -87,9 +93,9 @@ type Extract struct {
 //NewExtract creates a new data extraction
 func NewExtract(key, regExpr string, reset bool, required bool) *Extract {
 	return &Extract{
-		RegExpr: regExpr,
-		Key:     key,
-		Reset:   reset,
+		RegExpr:  regExpr,
+		Key:      key,
+		Reset:    reset,
 		Required: required,
 	}
 }

--- a/model/repeater.go
+++ b/model/repeater.go
@@ -6,6 +6,7 @@ import (
 	"github.com/viant/endly/model/criteria"
 	"github.com/viant/endly/util"
 	"github.com/viant/toolbox"
+	"github.com/viant/toolbox/data"
 )
 
 //SliceKey represents slice key
@@ -58,8 +59,18 @@ func (r *Repeater) runOnce(service *endly.AbstractService, callerInfo string, co
 	if out == nil {
 		return true, nil
 	}
+
 	extractableOutput, structuredOutput := util.AsExtractable(out)
 	if len(structuredOutput) > 0 {
+		if extractedData, ok := structuredOutput["Data"]; ok {
+			extractedDataMap := extractedData.(data.Map)
+			for k,v := range extractedDataMap {
+				// don't overwrite existing keys
+				if _, ok := extracted[k]; !ok {
+					extracted[k] = v
+				}
+			}
+		}
 		if len(r.Variables) > 0 {
 			err = r.Variables.Apply(structuredOutput, extracted)
 		}

--- a/model/repeater_test.go
+++ b/model/repeater_test.go
@@ -180,7 +180,7 @@ func TestRepeatable_Run(t *testing.T) {
 			},
 			Repeat:      10,
 			SleepTimeMs: 100,
-			Exit:        "$value:!/running/", //this is contains
+			Exit:        "$output:!/running/", //this is contains
 		}
 
 		manager := endly.New()
@@ -216,7 +216,7 @@ func TestRepeatable_Run(t *testing.T) {
 			},
 			Repeat:      10,
 			SleepTimeMs: 100,
-			Exit:        "$value:!/running/", //this is contains
+			Exit:        "$output:!/running/", //this is contains
 		}
 
 		manager := endly.New()
@@ -302,7 +302,7 @@ func TestRepeatable_Run(t *testing.T) {
 			},
 			Repeat:      10,
 			SleepTimeMs: 100,
-			Exit:        "$value:!/running/", //this is contains
+			Exit:        "$output:!/running/", //this is contains
 		}
 
 		manager := endly.New()


### PR DESCRIPTION
I was having issues with using an anchored regexp:
```
action: exec:run
    checkError: true
    target: $local
    errors: $errors
    extract:
      Key: release2Metadata
      RegExpr: "^\\s+Metadata:( )$"
      Required: true
```

It would catch on the first pass, but then it would try to match again against the entire output flattened. Which would look something like this:

```
...\r\n Metadata:  value \r\n Entries: ...
```
And the required would fail. This adds code to have the repeater pass in already extracted values and not fail on required if it doesn't match, but a value has already been populated.   