### PR TITLE
Fixed compilation on Go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
-	github.com/jhump/protoreflect v1.4.2
+	github.com/jhump/protoreflect v1.6.0
 	github.com/json-iterator/go v1.1.6 // indirect
 	github.com/klauspost/compress v1.7.1 // indirect
 	github.com/klauspost/cpuid v1.2.1 // indirect


### PR DESCRIPTION
The checksum fails in Go 1.13. This small change fixes the build