### PR TITLE
Fix extract required

### DIFF
--- a/model/extracts_test.go
+++ b/model/extracts_test.go
@@ -123,6 +123,20 @@ versionId: '2'`, "\n"),
 			},
 		},
 		{
+			desription: "single line no capture group, no match",
+			extracts: []*Extract{
+				{
+					Key:      "status",
+					RegExpr:  `"test-status":"[^\"]+"`,
+					Required: true,
+				},
+			},
+			inputs: []string{
+				`"testStatus":"running"`,
+			},
+			hasError: true,
+		},
+		{
 			desription: "single line missing required expression",
 			extracts: []*Extract{
 				{

--- a/model/extracts_test.go
+++ b/model/extracts_test.go
@@ -1,10 +1,11 @@
 package model
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/viant/endly"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/viant/endly"
 )
 
 func TestExtracts_Extract(t *testing.T) {
@@ -103,6 +104,22 @@ versionId: '2'`, "\n"),
 			},
 			expected: map[string]interface{}{
 				"status": "running",
+			},
+		},
+		{
+			desription: "single line no capture group",
+			extracts: []*Extract{
+				{
+					Key:      "status",
+					RegExpr:  `"testStatus":"[^\"]+"`,
+					Required: true,
+				},
+			},
+			inputs: []string{
+				`"testStatus":"running"`,
+			},
+			expected: map[string]interface{}{
+				"status": `"testStatus":"running"`,
 			},
 		},
 		{


### PR DESCRIPTION
Specifying a capture group like so would lead to a nil pointer panic:

```
extract:
  key: valueExists
  regexpr: "running: ok"
  required: true
```

I reworked the code to use the zero match (the entire match) if no capture group is specified. 