### PR TITLE
migrator service, s and a flag, windows os path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .tar.gz
 .gz
 local_test.go
+.vscode/

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/viant/endly/util"
 	"sort"
+
+	"github.com/viant/endly/util"
 
 	//Database/datastore dependencies
 
@@ -32,6 +33,7 @@ import (
 	_ "github.com/viant/endly/gen/static"
 	_ "github.com/viant/endly/shared/static" //load external resource like .csv .json files to mem storage
 
+	_ "github.com/viant/endly/migrator"
 	_ "github.com/viant/endly/workflow"
 	_ "github.com/viant/toolbox/storage/gs"
 	_ "github.com/viant/toolbox/storage/s3"
@@ -107,6 +109,7 @@ import (
 
 	"bufio"
 	"errors"
+
 	"github.com/viant/endly"
 	"github.com/viant/endly/cli"
 	"github.com/viant/endly/gen/web"
@@ -119,9 +122,6 @@ import (
 	"github.com/viant/toolbox/url"
 	"golang.org/x/crypto/ssh/terminal"
 
-	"github.com/google/gops/agent"
-	rec "github.com/viant/endly/testing/endpoint/http"
-	"gopkg.in/yaml.v2"
 	"log"
 	"net/http"
 	"os"
@@ -131,6 +131,10 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/google/gops/agent"
+	rec "github.com/viant/endly/testing/endpoint/http"
+	"gopkg.in/yaml.v2"
 )
 
 func init() {
@@ -243,13 +247,13 @@ func Bootstrap() {
 		return
 	}
 
-	if _, ok := flagset["s"]; ok {
-		printServiceActions()
+	if _, ok := flagset["a"]; ok {
+		printServiceActionRequest()
 		return
 	}
 
-	if _, ok := flagset["a"]; ok {
-		printServiceActionRequest()
+	if _, ok := flagset["s"]; ok {
+		printServiceActions()
 		return
 	}
 
@@ -705,7 +709,7 @@ func printVersion() {
 func getRunRequestURL(URL string) (*url.Resource, error) {
 	resource := url.NewResource(URL)
 	var candidates = make([]string, 0)
-	if path.Ext(resource.ParsedURL.Path) == "" {
+	if resource.ParsedURL != nil && path.Ext(resource.ParsedURL.Path) == "" {
 		candidates = append(candidates, URL+".json", URL+".yaml")
 	} else {
 		candidates = append(candidates, URL)

--- a/migrator/contract.go
+++ b/migrator/contract.go
@@ -1,0 +1,14 @@
+package migrator
+
+//MigratePostmanResponse represents a path to the workflow files
+type MigratePostmanResponse struct {
+	OutputPath string
+	Success    bool
+	Message    string
+}
+
+//MigratePostmanRequest represents a path to the postman files
+type MigratePostmanRequest struct {
+	CollectionPath string
+	OutputPath     string
+}

--- a/migrator/file_helper.go
+++ b/migrator/file_helper.go
@@ -1,0 +1,86 @@
+package migrator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/viant/toolbox"
+)
+
+const JSONExt = ".json"
+
+//*** IO Functions - harder to unit test ***
+
+func getPostmanObjects(path string) ([]*postmanObject, error) {
+	var objects []*postmanObject
+
+	jsonFilePaths, err := getJSONFilePaths(path)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range jsonFilePaths {
+		o, err := parsePostmanFile(p)
+		if err != nil {
+			return nil, err
+		}
+		objects = append(objects, o)
+	}
+
+	return objects, nil
+}
+
+func parsePostmanFile(path string) (*postmanObject, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsePostmanReader(f)
+}
+
+func getJSONFilePaths(path string) ([]string, error) {
+	var jsonFilePaths []string
+	if toolbox.IsDirectory(path) {
+		var err error
+		jsonFilePaths, err = getJsonFilesFromDir(path)
+		if err != nil {
+			return nil, err
+		}
+	} else if toolbox.FileExists(path) {
+		if hasJSONExtension(path) {
+			jsonFilePaths = append(jsonFilePaths, path)
+		} else {
+			return nil, fmt.Errorf("file is not a *.json file")
+		}
+	} else {
+		return nil, fmt.Errorf("invalid collection path")
+	}
+
+	return jsonFilePaths, nil
+}
+
+func getJsonFilesFromDir(path string) ([]string, error) {
+	var jsonFiles []string
+	err := filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if hasJSONExtension(info.Name()) {
+			jsonFiles = append(jsonFiles, filePath)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonFiles, nil
+}
+
+func hasJSONExtension(path string) bool {
+	return strings.Contains(path, JSONExt)
+}

--- a/migrator/helper.go
+++ b/migrator/helper.go
@@ -1,0 +1,117 @@
+package migrator
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"regexp"
+	"strings"
+)
+
+const VarScopeNode = "_postman_variable_scope"
+const ScopeValueEnv = "environment"
+const ScopeValueGlobal = "globals"
+const InfoNode = "info"
+const PostmanIdNode = "_postman_id"
+
+//*** logic helpers are cleaner to unit test so separate from file helpers ***
+
+func parsePostmanReader(r io.Reader) (*postmanObject, error) {
+	var nodes map[string]interface{}
+	var pt postmanType = notPostman
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(b, &nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	val, ok := nodes[VarScopeNode]
+	if ok {
+		if val == ScopeValueEnv {
+			pt = environment
+		} else if val == ScopeValueGlobal {
+			pt = globals
+		}
+	}
+
+	_, ok = nodes[InfoNode]
+	if ok {
+		_, ok = nodes[InfoNode].(map[string]interface{})[PostmanIdNode]
+		if ok {
+			pt = requests
+		}
+	} else if pt == notPostman {
+		return &postmanObject{
+			nodes:      nil,
+			objectType: pt,
+		}, nil
+	}
+
+	return &postmanObject{
+		nodes:      nodes,
+		objectType: pt,
+	}, nil
+}
+
+func convertToRunBuilder(objects []*postmanObject) *runBuilder {
+	b := NewRunBuilder()
+	for _, o := range objects {
+		switch o.objectType {
+		case environment:
+			e := b.addEnvironment(o.nodes["name"].(string))
+			for _, v := range o.nodes["values"].([]interface{}) {
+				m := v.(map[string]interface{})
+				e.addVariable(m["key"].(string), m["value"].(string))
+			}
+		case globals:
+			for _, v := range o.nodes["values"].([]interface{}) {
+				m := v.(map[string]interface{})
+				b.addVariable(m["key"].(string), m["value"].(string))
+			}
+		case requests:
+			for _, v := range o.nodes["variable"].([]interface{}) {
+				v := v.(map[string]interface{})
+				b.addVariable(v["key"].(string), v["value"].(string))
+			}
+
+			for _, v := range o.nodes["item"].([]interface{}) {
+				v := v.(map[string]interface{})
+				name := v["name"].(string)
+				m := v["request"].(map[string]interface{})
+				url := m["url"].(map[string]interface{})["raw"].(string)
+				r := b.addRequest(m["method"].(string), replaceEndlyVar(url), name)
+
+				if h, ok := m["header"]; ok {
+					h := h.([]interface{})
+					for _, i := range h {
+						i := i.(map[string]interface{})
+						key := i["key"].(string)
+						value := replaceEndlyVar(i["value"].(string))
+						r.addHeader(key, []string{value})
+					}
+				}
+
+				if b, ok := m["body"]; ok {
+					b := b.(map[string]interface{})
+					r.Body = replaceEndlyVar(b["raw"].(string))
+				}
+			}
+		}
+	}
+
+	return b
+}
+
+func makeDirOrFileName(str string) string {
+	str = strings.ReplaceAll(str, "_", " ")
+	return strings.ReplaceAll(regexp.MustCompile(`[^a-zA-Z0-9 ]+`).ReplaceAllString(str, ""), " ", "_")
+}
+
+func replaceEndlyVar(value string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(value, "{{", "${"), "}}", "}")
+}

--- a/migrator/init.go
+++ b/migrator/init.go
@@ -1,0 +1,9 @@
+package migrator
+
+import "github.com/viant/endly"
+
+func init() {
+	endly.Registry.Register(func() endly.Service {
+		return New()
+	})
+}

--- a/migrator/run_builder.go
+++ b/migrator/run_builder.go
@@ -1,0 +1,179 @@
+package migrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+//build to build the objects that will serialize into the run.yaml, send.yaml, request.json and environment json files
+const RunYaml = `
+init:
+  {{INIT_PART}}
+pipeline:
+  info:
+    action: print
+    message: $environment
+  runRequests:
+    tag: $pathMatch
+    data:
+      '${tagId}.[]requests': '@request.json'
+    subPath: requests/${index}_*
+    range: 1..{{REQUEST_LEN}}
+    template:
+      run:
+        init:
+          tagId: $tagId
+        action: run
+        request: '@send'
+`
+
+const SendYaml = `
+init:
+  req: ${data.${tagId}.requests}
+pipeline:
+  send:
+    action: 'http/runner:send'
+    requests: $req
+  test:
+    workflow: assert
+    actual: 
+      Code: $send.Responses[0].Code
+    expected:
+      Code: 404
+`
+
+type cookieBuilder struct {
+	Domain     string
+	Expires    string
+	HttpOnly   bool
+	MaxAge     int
+	Name       string
+	Path       string
+	Raw        string
+	RawExpires string
+	SameSite   int
+	Secure     bool
+	Unparsed   []string
+	Value      string
+}
+
+type requestBuilder struct {
+	Body    string              `json:",omitempty"`
+	Cookies []*cookieBuilder    `json:",omitempty"`
+	Header  map[string][]string `json:",omitempty"`
+	Method  string
+	URL     string
+	name    string
+}
+
+func (b *requestBuilder) addCookie() *cookieBuilder {
+	c := &cookieBuilder{}
+	b.Cookies = append(b.Cookies, c)
+	return c
+}
+
+func (b *requestBuilder) addHeader(key string, value []string) {
+	b.Header[key] = value
+}
+
+func (b *requestBuilder) TOJson() (string, error) {
+	s, err := json.MarshalIndent(b, "", "    ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(s), nil
+}
+
+type environmentBuilder struct {
+	Variables map[string]string
+	name      string
+}
+
+func (b *environmentBuilder) addVariable(key string, value string) {
+	b.Variables[key] = value
+}
+
+func (b *environmentBuilder) TOJson() (string, error) {
+	s, err := json.MarshalIndent(b.Variables, "", "    ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(s), nil
+}
+
+type runBuilder struct {
+	variables    map[string]interface{}
+	requests     []*requestBuilder
+	environments []*environmentBuilder
+}
+
+func (b *runBuilder) addEnvironment(name string) *environmentBuilder {
+	e := &environmentBuilder{
+		Variables: make(map[string]string),
+		name:      name,
+	}
+	b.environments = append(b.environments, e)
+	return e
+}
+
+func (b *runBuilder) addRequest(method string, uRL string, name string) *requestBuilder {
+	r := &requestBuilder{
+		Method: method,
+		URL:    uRL,
+		name:   name,
+		Header: make(map[string][]string),
+	}
+	b.requests = append(b.requests, r)
+	return r
+}
+
+func (b *runBuilder) addVariable(key string, value interface{}) {
+	b.variables[key] = value
+}
+
+func (b *runBuilder) sendToYaml() string {
+	return SendYaml
+}
+
+func (b *runBuilder) toYamlInitPart() string {
+	var sb strings.Builder
+
+	if len(b.environments) > 0 {
+		sb.WriteString("environment: ")
+		sb.WriteString("$AsData($Cat('")
+		sb.WriteString(makeDirOrFileName(b.environments[0].name))
+		sb.WriteString(".json'))\n")
+
+		for k := range b.environments[0].Variables {
+			sb.WriteString("  ")
+			sb.WriteString(k)
+			sb.WriteString(": $environment.")
+			sb.WriteString(k)
+			sb.WriteString("\n")
+		}
+	}
+
+	for k, v := range b.variables {
+		sb.WriteString("  ")
+		sb.WriteString(k)
+		sb.WriteString(": ")
+		sb.WriteString(v.(string))
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+func (b *runBuilder) runToYaml() string {
+	l := strings.TrimLeft(fmt.Sprintf("%03s", fmt.Sprint(len(b.requests))), " ")
+	return strings.ReplaceAll(strings.ReplaceAll(RunYaml, "{{INIT_PART}}", b.toYamlInitPart()), "{{REQUEST_LEN}}", l)
+}
+
+func NewRunBuilder() *runBuilder {
+	return &runBuilder{
+		variables: make(map[string]interface{}),
+	}
+}

--- a/migrator/service.go
+++ b/migrator/service.go
@@ -1,0 +1,124 @@
+package migrator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/viant/endly"
+)
+
+const ServiceID = "migrator"
+
+const (
+	migrateServicePostmanExample = `{
+  "Collection": {
+    "CollectionPath": "/path/to/collection/file/or/directory",
+    "OutputPath": "/path/where/endly/should/write/workflow"
+  },
+}`
+)
+
+type migratorService struct {
+	*endly.AbstractService
+}
+
+func (s *migratorService) migratePostman(context *endly.Context, request *MigratePostmanRequest) (*MigratePostmanResponse, error) {
+
+	postmanObjects, err := getPostmanObjects(request.CollectionPath)
+	if err != nil {
+		return nil, err
+	}
+	builder := convertToRunBuilder(postmanObjects)
+
+	for _, e := range builder.environments {
+		s, err := e.TOJson()
+		if err != nil {
+			return nil, err
+		}
+		err = os.WriteFile(filepath.Join(request.OutputPath, makeDirOrFileName(e.name)+".json"), []byte(s), 0644)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	requestsPath := filepath.Join(request.OutputPath, "requests")
+	err = os.Mkdir(requestsPath, 0750)
+	if err != nil {
+		return nil, err
+	}
+	for i, r := range builder.requests {
+		s, err := r.TOJson()
+		if err != nil {
+			return nil, err
+		}
+		index := strings.TrimLeft(fmt.Sprintf("%03s", fmt.Sprint(i+1)), " ")
+		dirName := filepath.Join(requestsPath, index+"_"+makeDirOrFileName(r.name))
+		err = os.Mkdir(dirName, 0750)
+		if err != nil {
+			return nil, err
+		}
+		err = os.WriteFile(filepath.Join(dirName, "request.json"), []byte(s), 0644)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	defaultPath := filepath.Join(request.OutputPath, "default")
+	err = os.Mkdir(defaultPath, 0750)
+	if err != nil {
+		return nil, err
+	}
+	err = os.WriteFile(filepath.Join(defaultPath, "send.yaml"), []byte(builder.sendToYaml()), 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	err = os.WriteFile(filepath.Join(request.OutputPath, "run.yaml"), []byte(builder.runToYaml()), 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MigratePostmanResponse{
+		OutputPath: request.OutputPath,
+		Success:    true,
+		Message:    "Success",
+	}, nil
+}
+
+func (s *migratorService) registerRoutes() {
+	s.Register(&endly.Route{
+		Action: "postman",
+		RequestInfo: &endly.ActionInfo{
+			Description: "Migrate postman collection to endly workflow excluding tests v2.1",
+			Examples: []*endly.UseCase{
+				{
+					Description: "migrate postman collection",
+					Data:        migrateServicePostmanExample,
+				},
+			},
+		},
+		RequestProvider: func() interface{} {
+			return &MigratePostmanRequest{}
+		},
+		ResponseProvider: func() interface{} {
+			return &MigratePostmanResponse{}
+		},
+		Handler: func(context *endly.Context, request interface{}) (interface{}, error) {
+			if req, ok := request.(*MigratePostmanRequest); ok {
+				return s.migratePostman(context, req)
+			}
+			return nil, fmt.Errorf("unsupported request type: %T", request)
+		},
+	})
+}
+
+func New() endly.Service {
+	var result = &migratorService{
+		AbstractService: endly.NewAbstractService(ServiceID),
+	}
+	result.AbstractService.Service = result
+	result.registerRoutes()
+	return result
+}

--- a/migrator/service_test.go
+++ b/migrator/service_test.go
@@ -1,0 +1,964 @@
+package migrator
+
+import (
+	"strings"
+	"testing"
+)
+
+const PostmanEnvironment = `
+{
+	"id": "eb212016-c2cc-4a44-ad7b-83eac2d2e4c2",
+	"name": "ENVIRONMENT_1",
+	"values": [
+		{
+			"key": "ENV1",
+			"value": "ENVIRONMENT_1",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "SECRET1",
+			"value": "SECRET_INITIAL",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "host",
+			"value": "localhost",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "port",
+			"value": "8086",
+			"type": "default",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2023-05-08T01:48:02.151Z",
+	"_postman_exported_using": "Postman/10.13.5"
+}
+`
+
+const PostmanGlobals = `
+{
+	"id": "fce9da78-c5ba-4510-86f2-f2affed810ac",
+	"values": [
+		{
+			"key": "GLOBAL_VAR1",
+			"value": "2",
+			"type": "default",
+			"enabled": true
+		}
+	],
+	"name": "Globals",
+	"_postman_variable_scope": "globals",
+	"_postman_exported_at": "2023-05-08T01:49:27.269Z",
+	"_postman_exported_using": "Postman/10.13.5"
+}
+`
+
+const PostmanRequest = `
+{
+	"info": {
+		"_postman_id": "ce0b29d5-45c1-45bc-b3f3-eba3647cdc25",
+		"name": "Endly Test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "643429"
+	},
+	"item": [
+		{
+			"name": "Get Request",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://{{host}}:{{port}}?test=1",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"query": [
+						{
+							"key": "test",
+							"value": "1"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Post Request",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Put Request",
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Patch Request",
+			"request": {
+				"method": "PATCH",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Delete Request",
+			"request": {
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Copy Request",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "COPY",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Head Request",
+			"request": {
+				"method": "HEAD",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Options Request",
+			"request": {
+				"method": "OPTIONS",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Link Request",
+			"request": {
+				"method": "LINK",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Unlink Request",
+			"request": {
+				"method": "UNLINK",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Purge Request",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "PURGE",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Lock Request",
+			"request": {
+				"method": "LOCK",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Unlock Request",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "UNLOCK",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Propfind Request",
+			"request": {
+				"method": "PROPFIND",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "View Request",
+			"request": {
+				"method": "VIEW",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Environment",
+						"value": "{{ENV1}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{ \"TestBody\": \"Test Value\" }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}"
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"pm.test(\"Status code is 200\", function () {",
+					"  pm.response.to.have.status(200);",
+					"});"
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "var1",
+			"value": "0",
+			"type": "string"
+		}
+	]
+}
+`
+
+//No _postman_id under info node
+const PostmanBadRequest = `
+{
+	"info": {
+		"name": "Endly Test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "643429"
+	},
+	"item": [
+		{
+			"name": "Get Request",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Test-Header-Secret",
+						"value": "{{SECRET1}}",
+						"type": "text"
+					},
+					{
+						"key": "Test-Header-Global",
+						"value": "{{GLOBAL_VAR1}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://{{host}}:{{port}}?test=1",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"query": [
+						{
+							"key": "test",
+							"value": "1"
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"pm.test(\"Status code is 200\", function () {",
+					"  pm.response.to.have.status(200);",
+					"});"
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "var1",
+			"value": "0",
+			"type": "string"
+		}
+	]
+}
+`
+
+const BadJson = `
+{
+	"bad":"comma",
+}
+`
+
+const EmptyString = ""
+
+const GoodJsonNotPostman = `
+{
+	"good":"json"
+}
+`
+
+func TestNegativeParseTest(t *testing.T) {
+	//Bad Json
+	r1 := strings.NewReader(BadJson)
+
+	_, err := parsePostmanReader(r1)
+
+	if err == nil {
+		t.Fatalf(`Parsing bad json did not throw error as expected`)
+	}
+
+	//Empty String
+	r2 := strings.NewReader(EmptyString)
+
+	_, err = parsePostmanReader(r2)
+
+	if err == nil {
+		t.Fatalf(`Parsing empty string did not throw error as expected`)
+	}
+
+	//Good Json Not Postman
+	r3 := strings.NewReader(GoodJsonNotPostman)
+
+	o, err := parsePostmanReader(r3)
+
+	if err != nil {
+		t.Fatalf(`Parsing good json so should not throw errors`)
+	}
+
+	if o.nodes != nil && o.objectType != notPostman {
+		t.Fatalf(`This is not postman json so result should be nil`)
+	}
+
+	//Good Json bad Postman Request
+	r4 := strings.NewReader(PostmanBadRequest)
+
+	o, err = parsePostmanReader(r4)
+
+	if err != nil {
+		t.Fatalf(`Parsing good json so should not throw errors`)
+	}
+
+	if o.nodes != nil && o.objectType != notPostman {
+		t.Fatalf(`This is a bad postman request so result should be nil`)
+	}
+}
+
+func TestParseEnvironment(t *testing.T) {
+	r1 := strings.NewReader(PostmanEnvironment)
+
+	o, err := parsePostmanReader(r1)
+	if err != nil {
+		t.Fatalf(`Parsing failed due to: %v`, err)
+	}
+
+	if o.objectType != environment {
+		t.Fatalf(`expected object type %v but got %v`, environment, o.objectType)
+	}
+}
+
+func TestParseGlobals(t *testing.T) {
+	r1 := strings.NewReader(PostmanGlobals)
+
+	o, err := parsePostmanReader(r1)
+	if err != nil {
+		t.Fatalf(`Parsing failed due to: %v`, err)
+	}
+
+	if o.objectType != globals {
+		t.Fatalf(`expected object type %v but got %v`, globals, o.objectType)
+	}
+}
+
+func TestParseRequest(t *testing.T) {
+	r1 := strings.NewReader(PostmanRequest)
+
+	o, err := parsePostmanReader(r1)
+	if err != nil {
+		t.Fatalf(`Parsing failed due to: %v`, err)
+	}
+
+	if o.objectType != requests {
+		t.Fatalf(`expected object type %v but got %v`, requests, o.objectType)
+	}
+}
+
+func TestRunBuilder(t *testing.T) {
+	b := NewRunBuilder()
+	b.addVariable("test", "1")
+	r := b.addRequest("Get", "http://localhost:8086", "Get Request")
+	r.Body = "{\"test\": \"value\"}"
+	r.addHeader("Content-Type", []string{"application/json"})
+	c := r.addCookie()
+	c.Domain = "localhost"
+	c.Expires = "Tue, 07 May 2024 01:19:28 GMT"
+	c.HttpOnly = true
+	c.MaxAge = 1
+	c.Name = "Cookie_1"
+	c.Raw = "Cookie_1=value; Path=/; Expires=Tue, 07 May 2024 01:19:28 GMT;"
+	c.RawExpires = "Expires=Tue, 07 May 2024 01:19:28 GMT"
+	c.SameSite = 1
+	c.Secure = false
+	c.Unparsed = []string{"Cookie_1=value", "Path=/", "Expires=Tue, 07 May 2024 01:19:28 GMT"}
+	c.Path = "/"
+	c.Value = "1"
+	e := b.addEnvironment("Environment 1")
+	e.addVariable("host", "localhost")
+	e.addVariable("port", "8081")
+	e = b.addEnvironment("Environment 2")
+	e.addVariable("host", "localhost")
+	e.addVariable("port", "8082")
+
+	if !(len(b.requests) == 1 && len(b.requests[0].Cookies) == 1 &&
+		b.requests[0].Header["Content-Type"][0] == "application/json") &&
+		b.variables["test"] == "1" && len(b.environments) == 2 && b.environments[1].Variables["port"] == "8082" {
+		t.Fatalf("runBuilder is broken")
+	}
+
+	_, err := b.requests[0].TOJson()
+	if err != nil {
+		t.Fatalf(`TOJson failed with the following: %q`, err)
+	}
+
+	_, err = b.environments[0].TOJson()
+	if err != nil {
+		t.Fatalf(`TOJson failed with the following: %q`, err)
+	}
+}
+
+func TestConvertToBuilder(t *testing.T) {
+	r1 := strings.NewReader(PostmanEnvironment)
+
+	e, err := parsePostmanReader(r1)
+	if err != nil {
+		t.Fatalf(`Parsing failed due to: %v`, err)
+	}
+
+	r1 = strings.NewReader(PostmanGlobals)
+
+	g, err := parsePostmanReader(r1)
+	if err != nil {
+		t.Fatalf(`Parsing failed due to: %v`, err)
+	}
+
+	r1 = strings.NewReader(PostmanRequest)
+
+	r, err := parsePostmanReader(r1)
+	if err != nil {
+		t.Fatalf(`Parsing failed due to: %v`, err)
+	}
+
+	b := convertToRunBuilder([]*postmanObject{e, g, r})
+
+	if !(b.environments[0].Variables["ENV1"] == "ENVIRONMENT_1" &&
+		b.variables["GLOBAL_VAR1"] == "2" &&
+		len(b.requests) == 15) {
+		t.Fatalf("Conversion to RunBuilder failed")
+	}
+}
+
+func TestMakeDirOrFileName(t *testing.T) {
+	s := makeDirOrFileName("!This #$%^is a_test")
+	if s != "This_is_a_test" {
+		t.Fatalf("Making a safe Directory or File name failed")
+	}
+}

--- a/migrator/types.go
+++ b/migrator/types.go
@@ -1,0 +1,15 @@
+package migrator
+
+type postmanType int64
+
+const (
+	requests postmanType = iota
+	environment
+	globals
+	notPostman
+)
+
+type postmanObject struct {
+	nodes      map[string]interface{}
+	objectType postmanType
+}


### PR DESCRIPTION
This update resolves an issue where windows paths caused a panic.  Toolbox updates have been requested separately to resolve windows path issues.  Currently the endly -r=run command fails on windows as toolbox does not parse windows paths without error.  As well the command endly -s=exec -a=run does not return the documentation for the action and only returns the documentation for the service.  This has been addressed.  Finally, a new Services has been added in a new package called migrator.  The migrator package is intended to assist in migrating from other tools to endly.  This initial implementation has one action for migrating from postman collections to endly workflows.