### PR TITLE
http/runner: add httpDefaults context state key for global timeout/client options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+  * http/runner: added `httpDefaults` context state key — workflows can publish a
+    map of default http client options from `init:` and every `http/runner:send`
+    / `http/runner:load` call merges them, letting a regression suite set
+    `TimeoutMs`/`RequestTimeoutMs`/`ResponseHeaderTimeoutMs` once instead of per
+    action. Per-action `options:` still override; the 120 s built-in floor is
+    unchanged. Also fixes a long-standing bug where setting any single option
+    (e.g. `FollowRedirects: false`) silently dropped the timeout defaults.
+
 ## March March 22 2022 0.70
   * Switched toolbox/ssh service to  github.com/viant/gosh
   * Switch toolbox/cred|secret with  github.com/viant/scy

--- a/service/testing/runner/http/README.md
+++ b/service/testing/runner/http/README.md
@@ -439,6 +439,30 @@ pipeline:
 - _TimeoutMs_               time.Duration
 
 
+**Global defaults (`httpDefaults`)**
+
+To avoid repeating the same `options:` block on every `http/runner:send` or
+`http/runner:load` action (e.g. across a regression suite), publish a
+`httpDefaults` map into the context state from a parent workflow's `init:`.
+Every `http/runner` call then merges these values into its client options.
+
+```yaml
+init:
+  httpDefaults:
+    TimeoutMs: 300000
+    RequestTimeoutMs: 300000
+    ResponseHeaderTimeoutMs: 180000
+```
+
+Precedence (highest wins):
+
+1. Per-action `options:` on the `http/runner:send` / `http/runner:load` action.
+2. `httpDefaults` in context state.
+3. Built-in 120 s fallback for `TimeoutMs` and `RequestTimeoutMs`.
+
+Omit `httpDefaults` to keep the prior behavior; any key the action sets
+explicitly still wins.
+
 
 <a name="load"></a>
 ## Stress testing

--- a/service/testing/runner/http/service.go
+++ b/service/testing/runner/http/service.go
@@ -26,12 +26,27 @@ import (
 const ServiceID = "http/runner"
 const RunnerID = "HttpRunner"
 
+// configureDefaultTransport raises http.DefaultTransport's per-host idle connection
+// limit once per process. Previously this assignment lived inside
+// applyDefaultTimeoutIfNeeded, which made it an unsynchronized global write on
+// every http/runner call — under stress tests with concurrent load actions that
+// was a data race on http.DefaultTransport.
+var configureDefaultTransport sync.Once
+
+func tuneDefaultTransport() {
+	configureDefaultTransport.Do(func() {
+		if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+			transport.MaxIdleConnsPerHost = 100
+		}
+	})
+}
+
 type service struct {
 	*endly.AbstractService
 }
 
 func (s *service) send(context *endly.Context, sendGroupRequest *SendRequest) (*SendResponse, error) {
-	client, err := toolbox.NewHttpClient(s.applyDefaultTimeoutIfNeeded(sendGroupRequest.httpOptions)...)
+	client, err := toolbox.NewHttpClient(s.applyDefaultTimeoutIfNeeded(context, sendGroupRequest.httpOptions)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send req: %v", err)
 	}
@@ -129,22 +144,49 @@ func (s *service) sendRequest(context *endly.Context, client *http.Client, reque
 	return nil
 }
 
-func (s *service) applyDefaultTimeoutIfNeeded(options []*toolbox.HttpOptions) []*toolbox.HttpOptions {
-	if len(options) > 0 {
-		return options
+// defaultHttpFloor returns the baseline client options applied when neither the
+// per-action options nor context.State()[HttpDefaultsKey] provide a value.
+// These keep pre-existing behavior: both default to 120s.
+func defaultHttpFloor() map[string]interface{} {
+	return map[string]interface{}{
+		"RequestTimeoutMs": 120000,
+		"TimeoutMs":        120000,
+	}
+}
+
+// applyDefaultTimeoutIfNeeded layers http client options with the following
+// precedence (highest wins): 1) per-action `options` on the SendRequest/LoadRequest,
+// 2) `httpDefaults` map in context state, 3) the hardcoded floor from defaultHttpFloor.
+// A nil context is tolerated so the helper can be unit-tested in isolation.
+func (s *service) applyDefaultTimeoutIfNeeded(context *endly.Context, options []*toolbox.HttpOptions) []*toolbox.HttpOptions {
+	tuneDefaultTransport()
+
+	has := func(key string) bool {
+		for _, o := range options {
+			if o.Key == key {
+				return true
+			}
+		}
+		return false
 	}
 
-	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
-	return []*toolbox.HttpOptions{
-		{
-			Key:   "RequestTimeoutMs",
-			Value: 120000,
-		},
-		{
-			Key:   "TimeoutMs",
-			Value: 120000,
-		},
+	if context != nil {
+		state := context.State()
+		if state.Has(HttpDefaultsKey) {
+			for k, v := range toolbox.AsMap(state.Get(HttpDefaultsKey)) {
+				if !has(k) {
+					options = append(options, &toolbox.HttpOptions{Key: k, Value: v})
+				}
+			}
+		}
 	}
+
+	for k, v := range defaultHttpFloor() {
+		if !has(k) {
+			options = append(options, &toolbox.HttpOptions{Key: k, Value: v})
+		}
+	}
+	return options
 }
 
 // resetContext resets context for variables with Reset flag set, and removes PreviousTripStateKey
@@ -242,7 +284,7 @@ func (s *service) stressTest(context *endly.Context, request *LoadRequest) (*Loa
 	metrics := &runtimeMetric{}
 
 	go s.emitMetrics(context, metrics, &done, request.Message)
-	if _, err := s.initClients(request, sendChannel, metrics, &done); err != nil {
+	if _, err := s.initClients(context, request, sendChannel, metrics, &done); err != nil {
 		return nil, err
 	}
 	partialTrips := newPartialStressTrips(capacity, sendChannel, waitGroup)
@@ -400,12 +442,12 @@ func buildStressTestTrip(request *LoadRequest, context *endly.Context, partials 
 	return trips, nil
 }
 
-func (s *service) initClients(request *LoadRequest, sendChannel chan *stressTestTrip, metric *runtimeMetric, done *uint32) ([]*http.Client, error) {
+func (s *service) initClients(context *endly.Context, request *LoadRequest, sendChannel chan *stressTestTrip, metric *runtimeMetric, done *uint32) ([]*http.Client, error) {
 	var clients = make([]*http.Client, request.ThreadCount)
 	var err error
 	for i := 0; i < request.ThreadCount; i++ {
 		var client *http.Client
-		options := s.applyDefaultTimeoutIfNeeded(request.httpOptions)
+		options := s.applyDefaultTimeoutIfNeeded(context, request.httpOptions)
 		if client, err = toolbox.NewHttpClient(options...); err != nil {
 			return nil, err
 		}

--- a/service/testing/runner/http/service_test.go
+++ b/service/testing/runner/http/service_test.go
@@ -1,0 +1,182 @@
+package http
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/viant/endly"
+	"github.com/viant/toolbox"
+)
+
+func optionsToMap(options []*toolbox.HttpOptions) map[string]interface{} {
+	out := make(map[string]interface{}, len(options))
+	for _, o := range options {
+		out[o.Key] = o.Value
+	}
+	return out
+}
+
+func newServiceForTest() *service {
+	return &service{AbstractService: endly.NewAbstractService(ServiceID)}
+}
+
+func newContextWithState(values map[string]interface{}) *endly.Context {
+	context := endly.New().NewContext(toolbox.NewContext())
+	state := context.State()
+	for k, v := range values {
+		state.Put(k, v)
+	}
+	return context
+}
+
+// TestApplyDefaultTimeout_NilContext ensures the helper never panics when called
+// without a context (keeps the function unit-testable and tolerant of callers
+// that haven't yet threaded context through).
+func TestApplyDefaultTimeout_NilContext(t *testing.T) {
+	s := newServiceForTest()
+
+	got := optionsToMap(s.applyDefaultTimeoutIfNeeded(nil, nil))
+
+	assert.Equal(t, 120000, got["RequestTimeoutMs"])
+	assert.Equal(t, 120000, got["TimeoutMs"])
+}
+
+// TestApplyDefaultTimeout_NoStateNoOptions preserves the pre-existing behavior:
+// with nothing supplied, the hardcoded 120s floor applies.
+func TestApplyDefaultTimeout_NoStateNoOptions(t *testing.T) {
+	s := newServiceForTest()
+	ctx := newContextWithState(nil)
+
+	got := optionsToMap(s.applyDefaultTimeoutIfNeeded(ctx, nil))
+
+	assert.Equal(t, 120000, got["RequestTimeoutMs"])
+	assert.Equal(t, 120000, got["TimeoutMs"])
+	assert.Len(t, got, 2)
+}
+
+// TestApplyDefaultTimeout_StateDefaultsApplied demonstrates the new feature:
+// a map under state[httpDefaults] is merged into the options for every
+// http/runner call, with any floor key not covered by state filled in.
+func TestApplyDefaultTimeout_StateDefaultsApplied(t *testing.T) {
+	s := newServiceForTest()
+	ctx := newContextWithState(map[string]interface{}{
+		HttpDefaultsKey: map[string]interface{}{
+			"TimeoutMs":               300000,
+			"ResponseHeaderTimeoutMs": 180000,
+		},
+	})
+
+	got := optionsToMap(s.applyDefaultTimeoutIfNeeded(ctx, nil))
+
+	assert.Equal(t, 300000, got["TimeoutMs"])
+	assert.Equal(t, 180000, got["ResponseHeaderTimeoutMs"])
+	assert.Equal(t, 120000, got["RequestTimeoutMs"], "floor fills in keys state didn't set")
+}
+
+// TestApplyDefaultTimeout_ActionOptionsWin confirms precedence: per-action
+// options beat state defaults, which beat the hardcoded floor.
+func TestApplyDefaultTimeout_ActionOptionsWin(t *testing.T) {
+	s := newServiceForTest()
+	ctx := newContextWithState(map[string]interface{}{
+		HttpDefaultsKey: map[string]interface{}{
+			"TimeoutMs":        300000,
+			"RequestTimeoutMs": 300000,
+		},
+	})
+	action := []*toolbox.HttpOptions{
+		{Key: "TimeoutMs", Value: 500}, // per-action wins
+	}
+
+	got := optionsToMap(s.applyDefaultTimeoutIfNeeded(ctx, action))
+
+	assert.Equal(t, 500, got["TimeoutMs"], "per-action option is preserved")
+	assert.Equal(t, 300000, got["RequestTimeoutMs"], "state fills in where action didn't set")
+}
+
+// TestApplyDefaultTimeout_FixesSilentOverride guards against regression of a
+// prior bug: setting any single option (e.g. FollowRedirects) used to drop the
+// 120s floor entirely because of a len(options)>0 short-circuit.
+func TestApplyDefaultTimeout_FixesSilentOverride(t *testing.T) {
+	s := newServiceForTest()
+	action := []*toolbox.HttpOptions{
+		{Key: "FollowRedirects", Value: false},
+	}
+
+	got := optionsToMap(s.applyDefaultTimeoutIfNeeded(nil, action))
+
+	assert.Equal(t, false, got["FollowRedirects"])
+	assert.Equal(t, 120000, got["RequestTimeoutMs"], "floor still applies alongside unrelated options")
+	assert.Equal(t, 120000, got["TimeoutMs"])
+}
+
+// TestApplyDefaultTimeout_ArbitraryKeys ensures httpDefaults is not limited to
+// timeouts — any key accepted by toolbox.HttpOptions (e.g. MaxIdleConns,
+// FollowRedirects) can be set globally.
+func TestApplyDefaultTimeout_ArbitraryKeys(t *testing.T) {
+	s := newServiceForTest()
+	ctx := newContextWithState(map[string]interface{}{
+		HttpDefaultsKey: map[string]interface{}{
+			"FollowRedirects": false,
+			"MaxIdleConns":    50,
+		},
+	})
+
+	got := optionsToMap(s.applyDefaultTimeoutIfNeeded(ctx, nil))
+
+	assert.Equal(t, false, got["FollowRedirects"])
+	assert.Equal(t, 50, got["MaxIdleConns"])
+}
+
+// TestApplyDefaultTimeout_StateNotAMap silently ignores a misconfigured
+// httpDefaults value rather than panicking, so a typo in the user's workflow
+// can't take down a regression run.
+func TestApplyDefaultTimeout_StateNotAMap(t *testing.T) {
+	s := newServiceForTest()
+	ctx := newContextWithState(map[string]interface{}{
+		HttpDefaultsKey: "not-a-map",
+	})
+
+	assert.NotPanics(t, func() {
+		got := s.applyDefaultTimeoutIfNeeded(ctx, nil)
+		assert.Len(t, got, 2, "only the floor should remain when state is malformed")
+		m := optionsToMap(got)
+		assert.Equal(t, 120000, m["TimeoutMs"])
+		assert.Equal(t, 120000, m["RequestTimeoutMs"])
+	})
+}
+
+// TestApplyDefaultTimeout_ExplicitZeroPreserved guards the corner case where a
+// user intentionally sets TimeoutMs: 0 (meaning "no client-side timeout").
+// Presence is checked by key name only, so the floor must not override.
+func TestApplyDefaultTimeout_ExplicitZeroPreserved(t *testing.T) {
+	s := newServiceForTest()
+	action := []*toolbox.HttpOptions{
+		{Key: "TimeoutMs", Value: 0},
+	}
+
+	got := optionsToMap(s.applyDefaultTimeoutIfNeeded(nil, action))
+
+	assert.Equal(t, 0, got["TimeoutMs"], "explicit zero must not be overridden by the floor")
+	assert.Equal(t, 120000, got["RequestTimeoutMs"])
+}
+
+// TestTuneDefaultTransport_IdempotentAndRaceFree documents that the global
+// transport tuning is one-shot (sync.Once) and safe under concurrent invocation
+// — formerly an unsynchronized write on every http/runner call.
+func TestTuneDefaultTransport_IdempotentAndRaceFree(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tuneDefaultTransport()
+		}()
+	}
+	wg.Wait()
+
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		assert.Equal(t, 100, transport.MaxIdleConnsPerHost)
+	}
+}

--- a/service/testing/runner/http/trips.go
+++ b/service/testing/runner/http/trips.go
@@ -14,6 +14,12 @@ const TripRequests = "Request"
 const TripResponses = "Response"
 const TripData = "Data"
 
+// HttpDefaultsKey is the context state key holding a map of default
+// http client options (e.g. TimeoutMs, RequestTimeoutMs, ResponseHeaderTimeoutMs).
+// Values under this key are merged into every http/runner:send and http/runner:load
+// call, but never override options set on the action itself.
+const HttpDefaultsKey = "httpDefaults"
+
 // Internal structure for managing all requests and responses
 type Trips data.Map
 


### PR DESCRIPTION
Workflows can now publish `httpDefaults: {TimeoutMs, RequestTimeoutMs, ...}` from a parent `init:` block and every http/runner:send and http/runner:load call merges the values into its client options, letting a regression suite configure timeouts once instead of on every action. Per-action `options:` still win; the 120s built-in floor is preserved.

Also fixes a latent bug where setting any single option (e.g. FollowRedirects: false) silently dropped the documented timeout defaults because of a len(options)>0 short-circuit, and moves the http.DefaultTransport.MaxIdleConnsPerHost mutation behind a sync.Once to close a data race on the load-test path.